### PR TITLE
Fix some buffer overflows

### DIFF
--- a/tools/sacd_extract/main.c
+++ b/tools/sacd_extract/main.c
@@ -418,7 +418,7 @@ int main(int argc, char* argv[])
 
                         for(j = 0; j < n_areas; j ++){
                             wchar_t *wide_filename;
-                            albumdir_loc = strdup(albumdir);
+                            strcpy(albumdir_loc, albumdir);
                             if(n_areas > 1){
                                 strcat(albumdir_loc, j ? " [multi]" : " [stereo]");
                             }
@@ -533,7 +533,7 @@ int main(int argc, char* argv[])
                         albumdir_loc = (char *)malloc(strlen(albumdir)+16);
 
                         for(j = 0; j < n_areas; j ++){
-                            albumdir_loc = strdup(albumdir);
+                            strcpy(albumdir_loc, albumdir);
                             if(n_areas > 1){
                                 strcat(albumdir_loc, j ? " [multi]" : " [stereo]");
                             }
@@ -555,7 +555,7 @@ int main(int argc, char* argv[])
                         for(j = 0; j < n_areas; j ++){
                             // create the output folder
                             // If both stereo and multi-ch tracks are getting processed, create separate directories
-                            albumdir_loc = strdup(albumdir);
+                            strcpy(albumdir_loc, albumdir);
                             if(n_areas > 1){
                                 strcat(albumdir_loc, j ? " [multi]" : " [stereo]");
                             }


### PR DESCRIPTION
strdup() returns a a pointer to a newly allocated string which results in a buffer
overflow if a strcat() is used later on. Replace this with a strcpy().
This fixes segfaults if "-2 -m" or "-e" is used with an ISO file as
source.