### PR TITLE
RFC: Allow debug build for gcc and clang

### DIFF
--- a/tools/sacd_extract/CMakeLists.txt
+++ b/tools/sacd_extract/CMakeLists.txt
@@ -61,14 +61,16 @@ include_directories("../../libs/libcommon")
 include_directories("../../libs/libdstdec")
 include_directories("../../libs/libid3")
 include_directories("../../libs/libsacd")
-
+ 
+STRING(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
 # Extra flags for GCC
-if (CMAKE_COMPILER_IS_GNUCC OR (CMAKE_C_COMPILER_ID MATCHES "Clang"))
+if (CMAKE_COMPILER_IS_GNUCC OR (CMAKE_C_COMPILER_ID MATCHES "Clang") AND 
+  NOT (CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG"))
   add_definitions(
       -pipe
       -Wall -Wextra -Wcast-align -Wpointer-arith -O3
       -Wno-unused-parameter -msse2)
-endif (CMAKE_COMPILER_IS_GNUCC OR (CMAKE_C_COMPILER_ID MATCHES "Clang"))
+endif ()
 
 if(WIN32)
     set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIRARIES} -lpthread -lws2_32 -liconv -static")


### PR DESCRIPTION
To make debugging easier adding -DCMAKE_BUILD_TYPE=debug to the initial
"cmake ." call will build a debuggable binary. Without this the build is done with "-g -O3" which _breaks_ debugging.