### PR TITLE
Fix compile error and host string parsing on macOS

### DIFF
--- a/libs/libsacd/sacd_input.c
+++ b/libs/libsacd/sacd_input.c
@@ -331,6 +331,10 @@ static sacd_input_t sacd_net_input_open(const char *target)
     pb_istream_t input;
     pb_ostream_t output;
     uint8_t zero = 0;
+    char host[256];
+
+    strncpy(host, target, strchr(target, ':') - target);
+    host[strchr(target, ':') - target] = '\0';
 
     /* Allocate the library structure */
     dev = (sacd_input_t) calloc(sizeof(*dev), 1);
@@ -354,7 +358,7 @@ static sacd_input_t sacd_net_input_open(const char *target)
 
     timeout_markstart(&tm); 
     err = inet_tryconnect(&dev->fd, 
-            substr(target, 0, strchr(target, ':') - target), 
+            host,
             atoi(strchr(target, ':') + 1), &tm);
     if (err)
     {

--- a/tools/sacd_extract/main.c
+++ b/tools/sacd_extract/main.c
@@ -90,7 +90,7 @@ static struct opts_s
 scarletbook_handle_t *handle;
 scarletbook_output_t *output;
 
-void mkdir_wrap(char *name, char *mode){
+void mkdir_wrap(char *name, int mode){
 #ifdef __MINGW32__
     wchar_t *wname;
     wname = (wchar_t *) charset_convert(name, strlen(name), "UTF-8", "UCS-2-INTERNAL");


### PR DESCRIPTION
This fixes an error when compiling under recent versions of macOS (wrong type passed to mkdir).

It also fixes a network connection error that looks like:
```
Failed to connect
libsacdread: Can't open x.x.x.x:2002 for reading
```

The original `substr(target, 0, strchr(target, ':') - target)` was causing the host/ip string to be truncated (at least on macOS), so it wasn't able to connect to the actual host.